### PR TITLE
fix: Ignore node dependencies properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Node.js dependencies
+node_modules
+package-lock.json
+*.log


### PR DESCRIPTION
Added a `.gitignore` file inside the root of the repository to properly ignore node dependencies when switching between branches that work in `./frontend` and `./backend`.

Closes #72 