### PR TITLE
feat: create Dockerfile for frontend

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,12 @@
+# Node
+node_modules
+*.log
+
+# Git
+.git
+.gitignore
+.gitattributes
+
+# Docker
+Dockerfile
+.dockerignore

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,26 @@
+# Base Stage
+FROM node:22.14.0-alpine AS base
+
+WORKDIR /app
+COPY package*.json ./
+
+# Development Stage
+FROM base AS development
+
+RUN npm install
+COPY . .
+EXPOSE 5173
+CMD ["npm", "run", "dev", "--", "--host"]
+
+# Production Build Stage
+FROM base AS build
+
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# Production HTML Server
+FROM nginx:alpine AS production
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
This PR adds two files to the repository:

1. frontend/Dockerfile
2. frontend/.dockerignore

They allow us to create images and run containers for development and production stages of the Quill app.

To create the images run:

-**Development**: `docker build --target development -t quill-frontend-dev .`
-**Production**: `docker build --target build -t quill-frontend-prod .`

To run the containers execute:

-**Development**: `docker run -p 5173:5173 --name quill-frontend-dev-container quill-frontend-dev`
-**Production**: `docker run -p 80:80 --name quill-frontend-prod-container quill-frontend-prod`

Closes #41 