### PR TITLE
Docs/user management api

### DIFF
--- a/backend/middlewares/authMiddleware.js
+++ b/backend/middlewares/authMiddleware.js
@@ -6,7 +6,7 @@ const verifyToken = async (req, res, next) => {
 
   // If no token is provided, return a 401 error response
   if (!token) {
-    return res.status(401).json({ error: "No token provided." });
+    return res.status(401).json({ error: "Authentication required." });
   }
 
   try {
@@ -27,7 +27,7 @@ const verifyToken = async (req, res, next) => {
       error.code === "auth/argument-error"
     ) {
       // Invalid or expired token
-      return res.status(401).json({ error: "Invalid or expired token." });
+      return res.status(401).json({ error: "Authentication required." });
     }
 
     // If it is not an invalid token error, it's a server-related issue

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -136,7 +136,7 @@ router.post("/register/employee", verifyToken, async (req, res) => {
     );
 
     if (!result || result.length === 0) {
-      return res.status(403).json({ error: "User not found." });
+      return res.status(403).json({ error: "Access Denied." });
     }
 
     const { role, department } = result[0];
@@ -189,7 +189,8 @@ router.post("/register/employee", verifyToken, async (req, res) => {
     }
 
     if (error.code === "ER_BAD_FIELD_ERROR") {
-      return res.status(404).json({ error: "Invalid department ID." });
+      console.error("Database error:", error);
+      return res.status(500).json({ error: "Internal server error." });
     }
 
     res.status(500).json({ error: error.message || "Internal server error." });

--- a/docs/api/backend-auth-api.json
+++ b/docs/api/backend-auth-api.json
@@ -36,7 +36,7 @@
           }
         },
         "responses": {
-          "201": { "description": "User registered successfully." },
+          "201": { "description": "Author registered successfully." },
           "400": { "description": "Invalid input." },
           "409": { "description": "Email already exists." },
           "500": { "description": "Internal server error." }
@@ -92,9 +92,8 @@
         "responses": {
           "201": { "description": "Employee registered successfully." },
           "400": { "description": "Invalid input." },
-          "401": { "description": "Invalid or expired token." },
-          "403": { "description": "User not found." },
-          "404": { "description": "Invalid department ID." },
+          "401": { "description": "Authentication required." },
+          "403": { "description": "Access Denied." },
           "409": { "description": "Email already exists." },
           "500": { "description": "Internal server error." }
         }

--- a/docs/api/backend-user-management-api.json
+++ b/docs/api/backend-user-management-api.json
@@ -1,0 +1,202 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Quill's User Management API",
+    "version": "1.0.0",
+    "description": "API for managing user data in Quill, including retrieval, creation, update, and deletion of user records."
+  },
+  "paths": {
+    "/api/users": {
+      "get": {
+        "summary": "Get a list of users",
+        "description": "Retrieve a paginated list of users.",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "List of users retrieved successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/User"
+                  }
+                }
+              }
+            }
+          },
+          "401": { "description": "Authentication required." },
+          "403": { "description": "Access Denied." },
+          "500": { "description": "Internal server error." }
+        }
+      },
+      "post": {
+        "summary": "Create a new user",
+        "description": "Create a new user in the system.",
+        "security": [{ "bearerAuth": [] }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": { "type": "string", "example": "John Doe" },
+                  "email": { "type": "string", "example": "john@example.com" },
+                  "password": { "type": "string", "example": "password123" },
+                  "role_id": { "type": "integer", "example": 2 }
+                },
+                "required": ["name", "email", "password", "role_id"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": { "description": "User created successfully." },
+          "400": { "description": "Invalid input." },
+          "401": { "description": "Authentication required." },
+          "403": { "description": "Access Denied." },
+          "500": { "description": "Internal server error." }
+        }
+      }
+    },
+    "/api/users/{userId}": {
+      "get": {
+        "summary": "Get user details",
+        "description": "Retrieve details of a specific user by their ID. Includes role-specific information if available.",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User details retrieved successfully.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/UserWithRole" }
+              }
+            }
+          },
+          "401": { "description": "Authentication required." },
+          "403": { "description": "Access Denied." },
+          "404": { "description": "User not found." },
+          "500": { "description": "Internal server error." }
+        }
+      },
+      "patch": {
+        "summary": "Update user details",
+        "description": "Update information of a specific user.",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": { "type": "string", "example": "John Doe" },
+                  "email": { "type": "string", "example": "john@example.com" },
+                  "role_id": { "type": "integer", "example": 2 }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "User updated successfully." },
+          "400": { "description": "Invalid input." },
+          "401": { "description": "Authentication required." },
+          "403": { "description": "Access Denied." },
+          "404": { "description": "User not found." },
+          "500": { "description": "Internal server error." }
+        }
+      },
+      "delete": {
+        "summary": "Delete user",
+        "description": "Remove a user from the system by their ID.",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "204": { "description": "User deleted successfully." },
+          "401": { "description": "Authentication required." },
+          "403": { "description": "Access Denied." },
+          "404": { "description": "User not found." },
+          "500": { "description": "Internal server error." }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer", "example": 1 },
+          "name": { "type": "string", "example": "John Doe" },
+          "email": { "type": "string", "example": "john@example.com" },
+          "role_id": { "type": "integer", "example": 2 },
+          "created_at": { "type": "string", "format": "date-time" }
+        }
+      },
+      "Author": {
+        "type": "object",
+        "properties": {
+          "bio": {
+            "type": "string",
+            "example": "Author of several books."
+          },
+          "website": {
+            "type": "string",
+            "example": "www.authorwebsite.ca"
+          }
+        }
+      },
+      "Employee": {
+        "type": "object",
+        "properties": {
+          "department": { "type": "string", "example": "Editorial" }
+        }
+      },
+      "UserWithRole": {
+        "allOf": [
+          { "$ref": "#/components/schemas/User" },
+          {
+            "oneOf": [
+              { "$ref": "#/components/schemas/Author" },
+              { "$ref": "#/components/schemas/Employee" }
+            ]
+          }
+        ]
+      }
+    },
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
+      }
+    }
+  },
+  "security": [{ "bearerAuth": [] }]
+}


### PR DESCRIPTION
This PR adds the User Management API following Open API Specification.

It defines a creation of a new communication endpoints for back-end:

- `/api/users` - _Get a list of users_ 
   - We currently don't have business rules about this endpoint logic, but we can consider that the authenticated user must have an **admin** role or a **employee** role and be a member of **Human Resources** or **Technology** department to be able to receive a **200** response from this endpoint.
- `/api/users/{userId}` with different actions:
   - `get` - _Get user details. With the addition of role based information_
      - Authors has bio and website
      - Employee has department
   - `patch` - _Update user details_
   - `delete` - _Delete user_

When developing all the actions above, they should only be accessed by authenticated users with valid business rules.
- Get - _by the own user, admin or approved employee department._
- Patch - _by the own user, admin or approved employee department._
- Delete - _by admin or approved employee department._

Since none of these business requirements weren't defined before, any suggestion for change is welcome.

Additionally, this PR updates the user authentication API documentation to create a pattern among the responses.
Consequently, there's also a fix on the back-end authentication middleware and authentication routes to match this change.

Closes #86 