### PR TITLE
docs: add manuscript tracking api specification

### DIFF
--- a/docs/api/backend-manuscript-tracking-api.json
+++ b/docs/api/backend-manuscript-tracking-api.json
@@ -168,7 +168,10 @@
           "description": { "type": "string" },
           "author": { "type": "string" },
           "current_step": { "type": "string" },
-          "assigned_department": { "type": "string" }
+          "assigned_department": {
+            "type": "array",
+            "items": { "type": "integer" }
+          }
         }
       },
       "Comment": {

--- a/docs/api/backend-manuscript-tracking-api.json
+++ b/docs/api/backend-manuscript-tracking-api.json
@@ -83,6 +83,7 @@
               }
             }
           },
+          "204": { "description": "No comments found for this manuscript." },
           "401": { "description": "Authentication required." },
           "403": { "description": "Access Denied." },
           "500": { "description": "Internal server error." }
@@ -118,6 +119,7 @@
           "201": {
             "description": "Comment added successfully."
           },
+          "400": { "description": "Invalid input." },
           "401": { "description": "Authentication required." },
           "403": { "description": "Access Denied." },
           "500": { "description": "Internal server error." }
@@ -141,6 +143,7 @@
           "200": {
             "description": "Manuscript advanced to the next step."
           },
+          "204": { "description": "No next step available to advance." },
           "401": { "description": "Authentication required." },
           "403": { "description": "Access Denied." },
           "500": { "description": "Internal server error." }
@@ -165,7 +168,6 @@
           "description": { "type": "string" },
           "author": { "type": "string" },
           "current_step": { "type": "string" },
-          "status": { "type": "string" },
           "assigned_department": { "type": "string" }
         }
       },
@@ -173,6 +175,7 @@
         "type": "object",
         "properties": {
           "id": { "type": "integer" },
+          "step_id": { "type": "integer" },
           "content": { "type": "string" },
           "created_at": { "type": "string", "format": "date-time" },
           "author": { "type": "string" }

--- a/docs/api/backend-manuscript-tracking-api.json
+++ b/docs/api/backend-manuscript-tracking-api.json
@@ -7,7 +7,7 @@
   },
   "security": [{ "bearerAuth": [] }],
   "paths": {
-    "/manuscripts": {
+    "/api/manuscripts": {
       "get": {
         "summary": "Get manuscripts for the authenticated user",
         "description": "Returns manuscripts based on the user's role (author or employee).",
@@ -30,7 +30,7 @@
         }
       }
     },
-    "/manuscripts/{id}": {
+    "/api/manuscripts/{id}": {
       "get": {
         "summary": "Get manuscript details",
         "description": "Retrieves details of a specific manuscript.",
@@ -58,7 +58,7 @@
         }
       }
     },
-    "/manuscripts/{id}/comments": {
+    "/api/manuscripts/{id}/comments": {
       "get": {
         "summary": "Get a manuscript comments",
         "description": "Retrieves comments for a specific manuscript.",
@@ -124,7 +124,7 @@
         }
       }
     },
-    "/manuscripts/{id}/advance": {
+    "/api/manuscripts/{id}/advance": {
       "post": {
         "summary": "Advance manuscript to the next workflow step",
         "description": "Allows an employee to move a manuscript to the next workflow step.",

--- a/docs/api/backend-manuscript-tracking-api.json
+++ b/docs/api/backend-manuscript-tracking-api.json
@@ -1,0 +1,183 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Manuscript Tracking API",
+    "version": "1.0.0",
+    "description": "API for tracking the manuscript workflow in Quill."
+  },
+  "security": [{ "bearerAuth": [] }],
+  "paths": {
+    "/manuscripts": {
+      "get": {
+        "summary": "Get manuscripts for the authenticated user",
+        "description": "Returns manuscripts based on the user's role (author or employee).",
+        "security": [{ "bearerAuth": [] }],
+        "responses": {
+          "200": {
+            "description": "List of manuscripts",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Manuscript" }
+                }
+              }
+            }
+          },
+          "401": { "description": "Authentication required." },
+          "403": { "description": "Access Denied." },
+          "500": { "description": "Internal server error." }
+        }
+      }
+    },
+    "/manuscripts/{id}": {
+      "get": {
+        "summary": "Get manuscript details",
+        "description": "Retrieves details of a specific manuscript.",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Manuscript details",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Manuscript" }
+              }
+            }
+          },
+          "401": { "description": "Authentication required." },
+          "403": { "description": "Access Denied." },
+          "500": { "description": "Internal server error." }
+        }
+      }
+    },
+    "/manuscripts/{id}/comments": {
+      "get": {
+        "summary": "Get a manuscript comments",
+        "description": "Retrieves comments for a specific manuscript.",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Manuscript comments",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Comment" }
+                }
+              }
+            }
+          },
+          "401": { "description": "Authentication required." },
+          "403": { "description": "Access Denied." },
+          "500": { "description": "Internal server error." }
+        }
+      },
+      "post": {
+        "summary": "Add a comment to a manuscript",
+        "description": "Allows an authenticated user to comment on a manuscript step.",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "content": { "type": "string" }
+                },
+                "required": ["content"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Comment added successfully."
+          },
+          "401": { "description": "Authentication required." },
+          "403": { "description": "Access Denied." },
+          "500": { "description": "Internal server error." }
+        }
+      }
+    },
+    "/manuscripts/{id}/advance": {
+      "post": {
+        "summary": "Advance manuscript to the next workflow step",
+        "description": "Allows an employee to move a manuscript to the next workflow step.",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Manuscript advanced to the next step."
+          },
+          "401": { "description": "Authentication required." },
+          "403": { "description": "Access Denied." },
+          "500": { "description": "Internal server error." }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
+      }
+    },
+    "schemas": {
+      "Manuscript": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "title": { "type": "string" },
+          "description": { "type": "string" },
+          "author": { "type": "string" },
+          "current_step": { "type": "string" },
+          "status": { "type": "string" },
+          "assigned_department": { "type": "string" }
+        }
+      },
+      "Comment": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "content": { "type": "string" },
+          "created_at": { "type": "string", "format": "date-time" },
+          "author": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/docs/api/backend-manuscript-tracking-api.json
+++ b/docs/api/backend-manuscript-tracking-api.json
@@ -149,6 +149,32 @@
           "500": { "description": "Internal server error." }
         }
       }
+    },
+    "/api/manuscripts/{id}/cancel": {
+      "post": {
+        "summary": "Cancel manuscript",
+        "description": "Moves a manuscript to the canceled workflow step.",
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Manuscript successfully moved to canceled step."
+          },
+          "400": {
+            "description": "Invalid request. Manuscript is already canceled."
+          },
+          "401": { "description": "Authentication required." },
+          "403": { "description": "Access denied." },
+          "500": { "description": "Internal server error." }
+        }
+      }
     }
   },
   "components": {


### PR DESCRIPTION
This pull request introduces a new API for tracking the manuscript workflow in Quill. The changes include defining endpoints for managing manuscripts, adding comments, and advancing workflow steps.

### New API Definition:

* Added `docs/api/backend-manuscript-tracking-api.json` to define the Manuscript Tracking API.

Endpoints and Operations:

* [`GET /manuscripts`]: Retrieves manuscripts for the authenticated user based on their role.
* [`GET /manuscripts/{id}`]: Retrieves details of a specific manuscript.
* [`GET /manuscripts/{id}/comments`]: Retrieves comments for a specific manuscript.
* [`POST /manuscripts/{id}/comments`]: Allows an authenticated user to add a comment to a manuscript.
* [`POST /manuscripts/{id}/advance`]: Allows an employee to advance a manuscript to the next workflow step.
* [`POST /manuscripts/{id}/cancel`]: Allows an employee to move a manuscript to the cancelled workflow step.

_Note_: The manuscripts comments are not part of this sprint/task. However, this functionality is intrinsically connected with the tracking of manuscript. We may choose not to develop the POST path, but we may develop the GET, so that comments may appear on the tracking manuscript screen.

Closes #103 